### PR TITLE
Dependent destroy for bookings

### DIFF
--- a/app/models/booking.rb
+++ b/app/models/booking.rb
@@ -1,4 +1,4 @@
 class Booking < ApplicationRecord
   belongs_to :user
-  belongs_to :activity
+  belongs_to :activity, dependent: destroy
 end


### PR DESCRIPTION
Added dependent: :destroy to booking model in order to allow activities to be deleted (together with their bookings)